### PR TITLE
Release build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
+release
 .idea
 unity/src/*.o

--- a/build.sh
+++ b/build.sh
@@ -2,3 +2,4 @@ git submodule update
 
 make clean
 make
+make release

--- a/setup.sh
+++ b/setup.sh
@@ -4,13 +4,12 @@ git submodule init
 git submodule update
 
 cd openssl
-./Configure --debug enable-ec_nistp_64_gcc_128 no-stdio no-ocsp no-nextprotoneg no-module \
+./Configure enable-ec_nistp_64_gcc_128 no-stdio no-ocsp no-nextprotoneg no-module \
             no-legacy no-gost no-engine no-dynamic-engine no-deprecated no-comp \
             no-cmp no-capieng no-ui-console no-tls no-ssl no-dtls no-aria no-bf \
             no-blake2 no-camellia no-cast no-chacha no-cmac no-des no-dh no-dsa \
             no-ecdh no-idea no-md4 no-mdc2 no-ocb no-poly1305 no-rc2 no-rc4 no-rmd160 \
             no-scrypt no-seed no-siphash no-siv no-sm2 no-sm3 no-sm4 no-whirlpool
-make
+make build_generated libcrypto.so
 
 cd ../
-./build.sh

--- a/src/besu_native_ec.h
+++ b/src/besu_native_ec.h
@@ -21,9 +21,45 @@
 extern "C" {
 #endif
 
-#include "ec_key_recovery.h"
-#include "ec_sign.h"
-#include "ec_verify.h"
+/**
+ * This header file includes all functions that are publicly exposed by
+ * the besu-native-ec library
+ */
+
+struct key_recovery_result {
+  // 131 bytes are needed for a P-521 public key
+  char public_key[131];
+  char error_message[256];
+};
+
+struct sign_result {
+  // 66 bytes are needed for one half of a P-521 signature
+  char signature_r[66];
+  char signature_s[66];
+  char signature_v;
+  char error_message[256];
+};
+
+struct verify_result {
+  int verified;
+  char error_message[256];
+};
+
+struct key_recovery_result p256_key_recovery(const char data_hash[],
+                                             const int data_hash_len,
+                                             const char signature_r[],
+                                             const char signature_s[],
+                                             const int signature_v);
+
+struct sign_result p256_sign(const char data_hash[], const int data_hash_length,
+                             const char private_key_data[],
+                             const char public_key_data[]);
+
+struct verify_result p256_verify(const char data_hash[],
+                                 const int data_hash_length,
+                                 const char signature_r[],
+                                 const char signature_s[],
+                                 const char public_key_data[]);
 
 #ifdef __cplusplus
 extern

--- a/src/constants.c
+++ b/src/constants.c
@@ -21,5 +21,5 @@ const int8_t SUCCESS = 1;
 const int8_t FAILURE = 0;
 const int8_t GENERIC_ERROR = -1;
 
-const int MAX_SIGNATURE_BUFFER_LEN = 263;
-const int MAX_PUBLIC_KEY_BUFFER_LEN = 263;
+const int MAX_SIGNATURE_BUFFER_LEN = 66;
+const int MAX_PUBLIC_KEY_BUFFER_LEN = 131;

--- a/src/ec_key_recovery.h
+++ b/src/ec_key_recovery.h
@@ -21,25 +21,11 @@
 extern "C" {
 #endif
 
-struct key_recovery_result {
-  // 263 = 262 bytes are needed for a P-521 public key + 1 byte for the null
-  // byte at the end
-  char public_key[263];
-  char error_message[256];
-};
-
-struct key_recovery_result p256_key_recovery(const unsigned char *data_hash,
-                                             const size_t data_hash_len,
-                                             const char *signature_r_hex,
-                                             const char *signature_s_hex,
-                                             unsigned int signature_v);
-
-struct key_recovery_result key_recovery(const unsigned char *data_hash,
-                                        size_t data_hash_len,
-                                        const char *signature_r_hex,
-                                        const char *signature_s_hex,
-                                        unsigned int signature_v, int curve_nid,
-                                        unsigned int curve_byte_length);
+struct key_recovery_result
+key_recovery(const char data_hash[], int data_hash_len,
+             const char signature_r_arr[], const char signature_s_arr[],
+             const int signature_v, const int curve_nid,
+             const int curve_byte_length);
 
 #ifdef __cplusplus
 extern

--- a/src/ec_sign.h
+++ b/src/ec_sign.h
@@ -26,40 +26,24 @@
 extern "C" {
 #endif
 
-struct sign_result {
-  // 263 = 262 bytes are needed for a P-521 signature + 1 byte for the null byte
-  // at the end
-  char signature_r[263];
-  char signature_s[263];
-  int signature_v;
-  char error_message[256];
-};
-
-struct sign_result p256_sign(const unsigned char *data_hash,
-                             const size_t data_hash_length,
-                             const unsigned char private_key_data[],
-                             const unsigned char public_key_data[]);
-
-struct sign_result
-sign(const unsigned char *data_hash, const size_t data_hash_len,
-     const unsigned char private_key_data[], uint8_t private_key_len,
-     const unsigned char public_key_data[], uint8_t public_key_len,
-     const char *group_name, int curve_nid);
+struct sign_result sign(const char data_hash[], const int data_hash_len,
+                        const char private_key_data[], int private_key_len,
+                        const char public_key_data[], int public_key_len,
+                        const char *group_name, int curve_nid);
 
 ECDSA_SIG *create_signature(EVP_PKEY *key, char *error_message,
                             const unsigned char *data_hash,
                             const size_t data_hash_length);
 
-int signature_to_hex_values(const ECDSA_SIG *signature, char *error_message,
-                            char **signature_r, char **signature_s);
+int signature_to_bin_values(const ECDSA_SIG *signature, char *error_message,
+                            char **signature_r, char **signature_s,
+                            const int signature_len);
 
-int calculate_signature_v(struct sign_result *result,
-                          const unsigned char *data_hash,
-                          const size_t data_hash_len, const char *signature_r,
-                          const char *signature_s,
-                          const unsigned char public_key_data[],
-                          uint8_t public_key_len, uint8_t private_key_len,
-                          int curve_nid);
+int calculate_signature_v(struct sign_result *result, const char data_hash[],
+                          const size_t data_hash_len, const char signature_r[],
+                          const char signature_s[],
+                          const char public_key_data[], uint8_t public_key_len,
+                          uint8_t curve_byte_len, int curve_nid);
 
 #ifdef __cplusplus
 extern

--- a/src/ec_verify.h
+++ b/src/ec_verify.h
@@ -23,29 +23,18 @@
 extern "C" {
 #endif
 
-struct verify_result {
-  int verified;
-  char error_message[256];
-};
-
-struct verify_result p256_verify(const unsigned char *data_hash,
-                                 const size_t data_hash_length,
-                                 const char *signature_r,
-                                 const char *signature_s,
-                                 const unsigned char public_key_data[]);
-
-struct verify_result verify(const unsigned char *data_hash,
-                            const size_t data_hash_length,
-                            const char *signature_r_hex,
-                            const char *signature_s_hex,
-                            const unsigned char public_key_data[],
-                            const char *group_name, uint8_t public_key_len);
+struct verify_result verify(const char data_hash[], const int data_hash_length,
+                            const char signature_r_hex[],
+                            const char signature_s_hex[],
+                            const char public_key_data[], int public_key_len,
+                            const char *group_name);
 
 int create_der_encoded_signature(unsigned char **der_encoded_signature,
                                  int *der_encoded_signature_len,
                                  char *error_message,
-                                 const char *signature_r_hex,
-                                 const char *signature_s_hex);
+                                 const char signature_r_arr[],
+                                 const char signature_s_arr[],
+                                 int signature_arr_len);
 #ifdef __cplusplus
 extern
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -65,10 +65,16 @@ unsigned char *hex_to_bin(const char *hex_string) {
   return data;
 }
 
-char *to_lower_case(char *s) {
-  for (char *p = s; *p; p++) {
-    *p = tolower(*p);
+char *hex_arr_to_str(const char *p, int p_len) {
+  int i;
+  char tmp[3];
+  int len = 2 * p_len + 1;
+  char *output = malloc(len);
+  memset(output, 0, len);
+  for (i = 0; i < p_len; i++) {
+    sprintf(tmp, "%02x", (unsigned char)p[i]);
+    strcat(output, tmp);
   }
 
-  return s;
+  return output;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,7 +23,7 @@ extern "C" {
 
 void set_error_message(char *error_message, const char *message_prefix);
 unsigned char *hex_to_bin(const char *hex_string);
-char *to_lower_case(char *s);
+char *hex_arr_to_str(const char *p, int p_len);
 
 #ifdef __cplusplus
 extern

--- a/test/test_ec_key_recovery.c
+++ b/test/test_ec_key_recovery.c
@@ -33,21 +33,26 @@ void p256_key_recovery_should_recover_correct_public_keys(
 
   for (int i = 0; i < test_vectors_len; i++) {
     unsigned char *data_bin = hex_to_bin(test_vectors[i].data);
+    char *signature_r_bin = (char *)hex_to_bin(test_vectors[i].signature_r);
+    char *signature_s_bin = (char *)hex_to_bin(test_vectors[i].signature_s);
+    char *public_key_bin = (char *)hex_to_bin(test_vectors[i].public_key);
 
     if (EVP_Digest(data_bin, strlen(test_vectors[i].data) / 2, md_value,
                    &md_value_len, md, NULL) != 1) {
       TEST_FAIL_MESSAGE("Hashing not successful");
     }
 
-    struct key_recovery_result result = p256_key_recovery(
-        md_value, md_value_len, test_vectors[i].signature_r,
-        test_vectors[i].signature_s, test_vectors[i].signature_v);
+    struct key_recovery_result result =
+        p256_key_recovery((const char *)md_value, md_value_len, signature_r_bin,
+                          signature_s_bin, test_vectors[i].signature_v);
 
     TEST_ASSERT_EQUAL_STRING("", result.error_message);
-    TEST_ASSERT_EQUAL_STRING(test_vectors[i].public_key,
-                             to_lower_case(result.public_key));
+    TEST_ASSERT_EQUAL_CHAR_ARRAY(public_key_bin, result.public_key, 64);
 
     free(data_bin);
+    free(signature_r_bin);
+    free(signature_s_bin);
+    free(public_key_bin);
   }
 }
 

--- a/test/test_ec_sign.c
+++ b/test/test_ec_sign.c
@@ -41,25 +41,25 @@ void p256_sign_should_create_valid_signatures(
     }
 
     struct sign_result result_sign =
-        p256_sign(md_value, md_value_len, private_key_bin, public_key_bin);
+        p256_sign((const char *)md_value, md_value_len,
+                  (const char *)private_key_bin, (const char *)public_key_bin);
 
     TEST_ASSERT_EQUAL_STRING("", result_sign.error_message);
 
     struct verify_result result_verify =
-        p256_verify(md_value, md_value_len, result_sign.signature_r,
-                    result_sign.signature_s, public_key_bin);
+        p256_verify((const char *)md_value, md_value_len, result_sign.signature_r,
+                    result_sign.signature_s, (const char *)public_key_bin);
 
     TEST_ASSERT_EQUAL_STRING("", result_verify.error_message);
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, result_verify.verified,
                                   "Signature verification not successful");
 
     struct key_recovery_result result_key_recovery =
-        p256_key_recovery(md_value, md_value_len, result_sign.signature_r,
+        p256_key_recovery((const char *)md_value, md_value_len, result_sign.signature_r,
                           result_sign.signature_s, result_sign.signature_v);
 
     TEST_ASSERT_EQUAL_STRING("", result_key_recovery.error_message);
-    TEST_ASSERT_EQUAL_STRING(test_vectors[i].public_key,
-                             to_lower_case(result_key_recovery.public_key));
+    TEST_ASSERT_EQUAL_CHAR_ARRAY(public_key_bin, result_key_recovery.public_key, 64);
 
     free(data_bin);
     free(private_key_bin);

--- a/test/test_ec_verify.c
+++ b/test/test_ec_verify.c
@@ -55,7 +55,9 @@ void p256_verify_should_verify_signatures_according_to_test_vectors(void) {
     }
 
     unsigned char *data_bin = hex_to_bin(test_vectors[i].data);
-    unsigned char *public_key_bin = hex_to_bin(test_vectors[i].public_key);
+    char *public_key_bin = (char *)hex_to_bin(test_vectors[i].public_key);
+    char *signature_r_bin = (char *)hex_to_bin(test_vectors[i].signature_r);
+    char *signature_s_bin = (char *)hex_to_bin(test_vectors[i].signature_s);
 
     if (EVP_Digest(data_bin, strlen(test_vectors[i].data) / 2, md_value,
                    &md_value_len, md, NULL) != 1) {
@@ -63,13 +65,15 @@ void p256_verify_should_verify_signatures_according_to_test_vectors(void) {
     }
 
     struct verify_result result =
-        p256_verify(md_value, md_value_len, test_vectors[i].signature_r,
-                    test_vectors[i].signature_s, public_key_bin);
+        p256_verify((const char *)md_value, md_value_len, signature_r_bin,
+                    signature_s_bin, (const char *)public_key_bin);
 
     TEST_ASSERT_EQUAL_INT(test_vectors[i].result, result.verified);
 
     free(data_bin);
     free(public_key_bin);
+    free(signature_r_bin);
+    free(signature_s_bin);
   }
 
   EVP_MD_free((EVP_MD *)md_sha224);


### PR DESCRIPTION
added release build, replaced returned values from hex strings to char arrays, use only char arrays and int in functions of besu_native_ec.h

Signed-off-by: Daniel Lehrner <daniel@io.builders>