### PR TITLE
make test emits non-zero error code when there are failing tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ PASSED = `grep -s PASS $(PATHR)*.txt`
 FAIL = `grep -s FAIL $(PATHR)*.txt`
 IGNORE = `grep -s IGNORE $(PATHR)*.txt`
 
+FAILURES = `bash -c '$(FAIL) | wc -w`
+
 test: $(BUILD_PATHS) $(RESULTS) $(CRYPTO_LIB_PATH)
 	@echo "-----------------------\nIGNORES:\n-----------------------"
 	@echo "$(IGNORE)"
@@ -63,6 +65,8 @@ test: $(BUILD_PATHS) $(RESULTS) $(CRYPTO_LIB_PATH)
 	@echo "-----------------------\nPASSED:\n-----------------------"
 	@echo "$(PASSED)"
 	@echo "\nDONE"
+
+	./check_failing_test.sh
 
 $(PATHR)%.txt: $(PATHB)%.$(TEST_EXTENSION)
 	-./$< > $@ 2>&1

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,6 @@ PASSED = `grep -s PASS $(PATHR)*.txt`
 FAIL = `grep -s FAIL $(PATHR)*.txt`
 IGNORE = `grep -s IGNORE $(PATHR)*.txt`
 
-FAILURES = `bash -c '$(FAIL) | wc -w`
-
 test: $(BUILD_PATHS) $(RESULTS) $(CRYPTO_LIB_PATH)
 	@echo "-----------------------\nIGNORES:\n-----------------------"
 	@echo "$(IGNORE)"

--- a/check_failing_test.sh
+++ b/check_failing_test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+FAIL=`grep -s FAIL ./build/results/*.txt`
+
+# if there is more than character in $FAIL, it means there are failing tests
+if [ ${#FAIL} -ge 1 ]; then
+  echo "There are failing tests"
+  exit 1
+fi


### PR DESCRIPTION
`make test` executes a bash script at the end to check if there are failing tests. If it is indeed so, it fails with a non-zero error code, which ensures that the pipeline will fail as well.

Signed-off-by: Daniel Lehrner <daniel@io.builders>