### PR TITLE
`signed char` in `signature_v` instead of simple `char`

### DIFF
--- a/src/besu_native_ec.h
+++ b/src/besu_native_ec.h
@@ -36,7 +36,7 @@ struct sign_result {
   // 66 bytes are needed for one half of a P-521 signature
   char signature_r[66];
   char signature_s[66];
-  char signature_v;
+  signed char signature_v;
   char error_message[256];
 };
 

--- a/src/ec_sign.c
+++ b/src/ec_sign.c
@@ -279,7 +279,7 @@ int calculate_signature_v(struct sign_result *result, const char data_hash[],
 
     if (memcmp(public_key_data, recovery_result.public_key, public_key_len) ==
         0) {
-      result->signature_v = (char)i;
+      result->signature_v = (signed char)i;
       break;
     }
   }


### PR DESCRIPTION
`char` is not specified to be signed or not in C.
On Android `char` defaults to unsigned, which leads to an out of range comparison warning (`-Wtautological-constant-out-of-range-compare`) and hence an error in build.
As `signature_v = -1` is valid, `signature_v` should be defined as `signed char`.