### PR TITLE
bump to openssl 3.5.0, add ec_verify overload for malleable signatures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,72 +3,30 @@ version: 2.1
 executors:
   standard:
     docker:
-      - image: cimg/base:2021.05 
+      - image: cimg/base:2021.05
 
 jobs:
   check-code-format:
     executor: standard
     steps:
-      - checkout
       - run:
-          name: Install dependencies
-          command: |
-            sudo apt-get update
-            sudo apt-get -y install clang-format
-      - run:
-          name: Check code formatting
-          command: |
-            cd src && clang-format --dry-run --Werror *.c *.h
-            cd ../test && clang-format --dry-run --Werror *.c
+          name: No-op for check-code-format
+          command: echo "Skipping code format check (no-op)"
 
   build:
     executor: standard
     steps:
       - run:
-          name: Install dependencies
-          command: |
-            sudo apt-get update
-            sudo apt-get -y install build-essential automake autoconf libtool patchelf
-      - checkout
-      - run: git submodule init
-      - run: git submodule update
-      - run:
-          name: Build OpenSSL
-          command: |
-            cd openssl
-            ./Configure enable-ec_nistp_64_gcc_128 no-stdio no-ocsp no-nextprotoneg no-module \
-                        no-legacy no-gost no-engine no-dynamic-engine no-deprecated no-comp \
-                        no-cmp no-capieng no-ui-console no-tls no-ssl no-dtls no-aria no-bf \
-                        no-blake2 no-camellia no-cast no-chacha no-cmac no-des no-dh no-dsa \
-                        no-ecdh no-idea no-md4 no-mdc2 no-ocb no-poly1305 no-rc2 no-rc4 no-rmd160 \
-                        no-scrypt no-seed no-siphash no-siv no-sm2 no-sm3 no-sm4 no-whirlpool
-            make build_generated libcrypto.so
-            cd ../
-      - run:
-          name: Build project
-          command: |
-            make
-      - persist_to_workspace:
-          root: build
-          paths:
-            - test_*.out
-            - libs
+          name: No-op for build
+          command: echo "Skipping build (no-op)"
 
   check-memory-leaks:
     executor: standard
     steps:
-      - checkout
-      - attach_workspace:
-          at: build
       - run:
-          name: Install dependencies
-          command: |
-            sudo apt-get update
-            sudo apt-get -y install valgrind
-      - run:
-          name: Check for memory leaks
-          command: |
-            ls build/test_*.out | xargs -n 1 valgrind --leak-check=full --error-exitcode=255
+          name: No-op for check-memory-leaks
+          command: echo "Skipping memory leak check (no-op)"
+
 workflows:
   main:
     jobs:
@@ -79,3 +37,4 @@ workflows:
       - check-memory-leaks:
           requires:
             - build
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check-code-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install clang-format
+
+      - name: Check code formatting
+        run: |
+          cd src && clang-format --dry-run --Werror *.c *.h
+          cd ../test && clang-format --dry-run --Werror *.c
+
+  build:
+    runs-on: ubuntu-latest
+    needs: check-code-format
+    steps:
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install build-essential automake autoconf libtool patchelf
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize submodules
+        run: git submodule init
+
+      - name: Update submodules
+        run: git submodule update
+
+      - name: Build OpenSSL
+        run: |
+          cd openssl
+          ./Configure enable-ec_nistp_64_gcc_128 no-stdio no-ocsp no-nextprotoneg no-module \
+                      no-legacy no-gost no-engine no-dynamic-engine no-deprecated no-comp \
+                      no-cmp no-capieng no-ui-console no-tls no-ssl no-dtls no-aria no-bf \
+                      no-blake2 no-camellia no-cast no-chacha no-cmac no-des no-dh no-dsa \
+                      no-ecdh no-idea no-md4 no-mdc2 no-ocb no-poly1305 no-rc2 no-rc4 no-rmd160 \
+                      no-scrypt no-seed no-siphash no-siv no-sm2 no-sm3 no-sm4 no-whirlpool
+          make build_generated libcrypto.so
+          cd ../
+
+      - name: Build project
+        run: make
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            build/test_*.out
+            build/libs
+
+  check-memory-leaks:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+          path: build
+
+      - name: Install valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install valgrind
+
+      - name: Check for memory leaks
+        run: |
+          chmod +x build/test_*.out
+          ls build/test_*.out | xargs -n 1 valgrind --leak-check=full --error-exitcode=255
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "openssl"]
 	path = openssl
-	url = git@github.com:openssl/openssl.git
+	url = https://github.com/openssl/openssl.git

--- a/src/besu_native_ec.h
+++ b/src/besu_native_ec.h
@@ -61,6 +61,12 @@ struct verify_result p256_verify(const char data_hash[],
                                  const char signature_s[],
                                  const char public_key_data[]);
 
+struct verify_result p256_verify_malleable_signature(const char data_hash[],
+                                                     const int data_hash_length,
+                                                     const char signature_r[],
+                                                     const char signature_s[],
+                                                     const char public_key_data[]);
+
 #ifdef __cplusplus
 extern
 }

--- a/src/besu_native_ec.h
+++ b/src/besu_native_ec.h
@@ -61,11 +61,10 @@ struct verify_result p256_verify(const char data_hash[],
                                  const char signature_s[],
                                  const char public_key_data[]);
 
-struct verify_result p256_verify_malleable_signature(const char data_hash[],
-                                                     const int data_hash_length,
-                                                     const char signature_r[],
-                                                     const char signature_s[],
-                                                     const char public_key_data[]);
+struct verify_result p256_verify_malleable_signature(
+    const char data_hash[], const int data_hash_length,
+    const char signature_r[], const char signature_s[],
+    const char public_key_data[]);
 
 #ifdef __cplusplus
 extern

--- a/src/ec_verify.c
+++ b/src/ec_verify.c
@@ -15,8 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <stdio.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 #include "openssl/include/openssl/ec.h"
 #include "openssl/include/openssl/evp.h"
@@ -39,17 +39,15 @@ struct verify_result p256_verify(const char data_hash[],
                 NID_X9_62_prime256v1, false);
 }
 
-struct verify_result p256_verify_malleable_signature(const char data_hash[],
-                                                 const int data_hash_length,
-                                                 const char signature_r_hex[],
-                                                 const char signature_s_hex[],
-                                                 const char public_key_data[]) {
+struct verify_result p256_verify_malleable_signature(
+    const char data_hash[], const int data_hash_length,
+    const char signature_r_hex[], const char signature_s_hex[],
+    const char public_key_data[]) {
   static const uint8_t P256_PUBLIC_KEY_LENGTH = 64;
 
-  return verify(data_hash, data_hash_length,
-                signature_r_hex, signature_s_hex,
-                public_key_data, P256_PUBLIC_KEY_LENGTH,
-                "prime256v1", NID_X9_62_prime256v1, true);
+  return verify(data_hash, data_hash_length, signature_r_hex, signature_s_hex,
+                public_key_data, P256_PUBLIC_KEY_LENGTH, "prime256v1",
+                NID_X9_62_prime256v1, true);
 }
 
 struct verify_result verify(const char data_hash[], const int data_hash_length,
@@ -68,7 +66,8 @@ struct verify_result verify(const char data_hash[], const int data_hash_length,
   int signature_arr_len = public_key_len / 2;
   int is_canonicalized = 0;
 
-  if (!allow_malleable_signature && (is_canonicalized = is_signature_canonicalized(
+  if (!allow_malleable_signature &&
+      (is_canonicalized = is_signature_canonicalized(
            signature_s_arr, signature_arr_len, curve_nid,
            result.error_message)) == GENERIC_ERROR) {
     goto end;

--- a/src/ec_verify.h
+++ b/src/ec_verify.h
@@ -15,8 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #pragma once
 
@@ -28,14 +28,13 @@ struct verify_result verify(const char data_hash[], const int data_hash_length,
                             const char signature_r_hex[],
                             const char signature_s_hex[],
                             const char public_key_data[], int public_key_len,
-                            const char *group_name, int curve_nid, bool allow_malleable_signature);
+                            const char *group_name, int curve_nid,
+                            bool allow_malleable_signature);
 
-struct verify_result p256_verify_malleable_signature(const char data_hash[],
-                                                 const int data_hash_length,
-                                                 const char signature_r_hex[],
-                                                 const char signature_s_hex[],
-                                                 const char public_key_data[]);
-
+struct verify_result p256_verify_malleable_signature(
+    const char data_hash[], const int data_hash_length,
+    const char signature_r_hex[], const char signature_s_hex[],
+    const char public_key_data[]);
 
 int create_der_encoded_signature(unsigned char **der_encoded_signature,
                                  int *der_encoded_signature_len,

--- a/src/ec_verify.h
+++ b/src/ec_verify.h
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <stdint.h>
+#include <stdbool.h>
 
 #pragma once
 
@@ -27,7 +28,14 @@ struct verify_result verify(const char data_hash[], const int data_hash_length,
                             const char signature_r_hex[],
                             const char signature_s_hex[],
                             const char public_key_data[], int public_key_len,
-                            const char *group_name, int curve_nid);
+                            const char *group_name, int curve_nid, bool allow_malleable_signature);
+
+struct verify_result p256_verify_malleable_signature(const char data_hash[],
+                                                 const int data_hash_length,
+                                                 const char signature_r_hex[],
+                                                 const char signature_s_hex[],
+                                                 const char public_key_data[]);
+
 
 int create_der_encoded_signature(unsigned char **der_encoded_signature,
                                  int *der_encoded_signature_len,

--- a/test/test_ec_verify.c
+++ b/test/test_ec_verify.c
@@ -70,10 +70,9 @@ void p256_verify_should_verify_signatures_according_to_test_vectors(void) {
                     signature_s_bin, (const char *)public_key_bin);
 
     // malleable signature verify (canonicalization ignored)
-    struct verify_result malleable_result =
-        p256_verify_malleable_signature((const char *)md_value, md_value_len,
-                                    signature_r_bin, signature_s_bin,
-                                    (const char *)public_key_bin);
+    struct verify_result malleable_result = p256_verify_malleable_signature(
+        (const char *)md_value, md_value_len, signature_r_bin, signature_s_bin,
+        (const char *)public_key_bin);
 
     TEST_ASSERT_EQUAL_INT(test_vectors[i].result, result.verified);
 


### PR DESCRIPTION
Description says it all.  This is in support of EIP-7951

relates to: besu [issue 8605](https://github.com/hyperledger/besu/issues/8605)
relates to: besu-native [PR 270](https://github.com/hyperledger/besu-native/pull/270)

Also ditches circleCI in favor of github actions