### PR TITLE
fix: static-link OpenSSL to prevent symbol leaking into JVM process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,13 +71,17 @@ jobs:
           echo "Exported symbols:"
           nm -D release/libbesu_native_ec.so | grep " T "
 
-      - name: Upload build artifacts
+      - name: Upload test artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts
-          path: |
-            build/test_*.out
-            release/libbesu_native_ec.so
+          name: test-artifacts
+          path: build/test_*.out
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: release/libbesu_native_ec.so
 
   check-memory-leaks:
     runs-on: ubuntu-latest
@@ -86,10 +90,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download build artifacts
+      - name: Download test artifacts
         uses: actions/download-artifact@v4
         with:
-          name: build-artifacts
+          name: test-artifacts
           path: build
 
       - name: Install valgrind

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install build-essential automake autoconf libtool patchelf
+          sudo apt-get -y install build-essential automake autoconf libtool
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,20 +40,36 @@ jobs:
       - name: Update submodules
         run: git submodule update
 
-      - name: Build OpenSSL
+      - name: Build OpenSSL (static)
         run: |
           cd openssl
-          ./Configure enable-ec_nistp_64_gcc_128 no-stdio no-ocsp no-nextprotoneg no-module \
+          ./Configure no-shared -fPIC -fvisibility=hidden \
+                      enable-ec_nistp_64_gcc_128 no-stdio no-ocsp no-nextprotoneg no-module \
                       no-legacy no-gost no-engine no-dynamic-engine no-deprecated no-comp \
                       no-cmp no-capieng no-ui-console no-tls no-ssl no-dtls no-aria no-bf \
                       no-blake2 no-camellia no-cast no-chacha no-cmac no-des no-dh no-dsa \
                       no-ecdh no-idea no-md4 no-mdc2 no-ocb no-poly1305 no-rc2 no-rc4 no-rmd160 \
                       no-scrypt no-seed no-siphash no-siv no-sm2 no-sm3 no-sm4 no-whirlpool
-          make build_generated libcrypto.so
+          make build_generated libcrypto.a
           cd ../
 
-      - name: Build project
+      - name: Build and test
         run: make
+
+      - name: Build release
+        run: make release_build
+
+      - name: Verify no OpenSSL symbols exported
+        run: |
+          LEAKED=$(nm -D release/libbesu_native_ec.so | grep -c " T.*EVP_\| T.*EC_\| T.*ossl_" || true)
+          echo "Leaked OpenSSL symbols: $LEAKED"
+          if [ "$LEAKED" -gt 0 ]; then
+            echo "ERROR: OpenSSL symbols are leaking from libbesu_native_ec.so"
+            nm -D release/libbesu_native_ec.so | grep " T.*EVP_\| T.*EC_\| T.*ossl_"
+            exit 1
+          fi
+          echo "Exported symbols:"
+          nm -D release/libbesu_native_ec.so | grep " T "
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -61,7 +77,7 @@ jobs:
           name: build-artifacts
           path: |
             build/test_*.out
-            build/libs
+            release/libbesu_native_ec.so
 
   check-memory-leaks:
     runs-on: ubuntu-latest
@@ -85,4 +101,3 @@ jobs:
         run: |
           chmod +x build/test_*.out
           ls build/test_*.out | xargs -n 1 valgrind --leak-check=full --error-exitcode=255
-

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ PATHRO = build/release/objs/
 PATH_OPENSSL = openssl/
 PATH_OPENSSL_INCLUDE = openssl/include/
 
+# OpenSSL is linked statically to avoid leaking symbols into the JVM process.
+# See: https://github.com/hyperledger/besu-native/issues/XXX
+OPENSSL_STATIC_LIB = $(PATH_OPENSSL)libcrypto.a
+
 ifeq ($(OS),Windows_NT)
   ifeq ($(shell uname -s),) # not in a bash-like shell
 	CLEANUP = del /F /Q
@@ -28,32 +32,23 @@ else
 	TEST_EXTENSION=out
 	ifeq ($(shell uname -s),Darwin) # on MacOS
 		LIBRARY_EXTENSION=dylib
-		OPENSSL_LIB_CRYPTO=$(PATH_OPENSSL)libcrypto.3.$(LIBRARY_EXTENSION)
 	else # on Linux
 		LIBRARY_EXTENSION=so
-		OPENSSL_LIB_CRYPTO=$(PATH_OPENSSL)libcrypto.$(LIBRARY_EXTENSION).3
 	endif
 endif
 
 .PHONY: clean
 .PHONY: test
 
-# libcrypto from OpenSSL will be renamed to this, to avoid naming conflicts
-CRYPTO_LIB=besu_native_ec_crypto
-CRYPTO_LIB_PATH=$(PATHL)lib$(CRYPTO_LIB).$(LIBRARY_EXTENSION)
-
 BUILD_PATHS = $(PATHB) $(PATHO) $(PATHR) ${PATHL}
 
 SRCT = $(wildcard $(PATHT)*.c)
 
 COMPILE=gcc -c -Wall -Werror -std=c11 -O3 -fPIC
-
-# this is used in the tests to find the local copy of the crypto library
-LINK_TEST=gcc -L$(PATHL) -Wl,-rpath $(PATHL)
-# this is used for the  besu_native_ec library release. The crypto library will be in the same folder as it,
-# because they are shipped later in a jar file together
-LINK_RELEASE=gcc -L$(PATHL) -Wl,-rpath ./
 COMPILE_FLAGS=-I. -I$(PATHU) -I$(PATHS) -I$(PATH_OPENSSL_INCLUDE) -DTEST
+
+# Link tests against the static OpenSSL library
+LINK_TEST=gcc
 
 # the following commands are used to create the console output of the tests
 RESULTS = $(patsubst $(PATHT)test_%.c,$(PATHR)test_%.txt,$(SRCT) )
@@ -62,7 +57,7 @@ PASSED = `grep -s PASS $(PATHR)*.txt`
 FAIL = `grep -s FAIL $(PATHR)*.txt`
 IGNORE = `grep -s IGNORE $(PATHR)*.txt`
 
-test: $(BUILD_PATHS) $(RESULTS) $(CRYPTO_LIB_PATH)
+test: $(BUILD_PATHS) $(RESULTS)
 	@echo "-----------------------\nIGNORES:\n-----------------------"
 	@echo "$(IGNORE)"
 	@echo "-----------------------\nFAILURES:\n-----------------------"
@@ -78,12 +73,12 @@ $(PATHR)%.txt: $(PATHB)%.$(TEST_EXTENSION)
 	-./$< > $@ 2>&1
 
 # the sign test uses the verification and key recovery as well, therefore those are added to its dependencies
-$(PATHB)test_ec_sign.$(TEST_EXTENSION): $(CRYPTO_LIB_PATH) $(PATHO)test_ec_sign.o $(PATHO)ec_sign.o $(PATHO)ec_verify.o $(PATHO)ec_key_recovery.o $(PATHU)unity.o $(PATHO)constants.o $(PATHO)utils.o $(PATHO)ec_key.o
-	$(LINK_TEST) -Wl,-rpath $(PATHL) $(CFLAGS) -o $@ $^ -l$(CRYPTO_LIB) -lc
+$(PATHB)test_ec_sign.$(TEST_EXTENSION): $(PATHO)test_ec_sign.o $(PATHO)ec_sign.o $(PATHO)ec_verify.o $(PATHO)ec_key_recovery.o $(PATHU)unity.o $(PATHO)constants.o $(PATHO)utils.o $(PATHO)ec_key.o
+	$(LINK_TEST) $(CFLAGS) -o $@ $^ $(OPENSSL_STATIC_LIB) -lc
 
-# the other test don't have other dependencies and are compiled an their own
-$(PATHB)test_%.$(TEST_EXTENSION): $(CRYPTO_LIB_PATH) $(PATHO)test_%.o $(PATHO)%.o $(PATHU)unity.o $(PATHO)constants.o $(PATHO)utils.o $(PATHO)ec_key.o
-	$(LINK_TEST) -Wl,-rpath $(PATHL) $(CFLAGS) -o $@ $^ -l$(CRYPTO_LIB) -lc
+# the other test don't have other dependencies and are compiled on their own
+$(PATHB)test_%.$(TEST_EXTENSION): $(PATHO)test_%.o $(PATHO)%.o $(PATHU)unity.o $(PATHO)constants.o $(PATHO)utils.o $(PATHO)ec_key.o
+	$(LINK_TEST) $(CFLAGS) -o $@ $^ $(OPENSSL_STATIC_LIB) -lc
 
 # creates the test object files from the test *.c files
 $(PATHO)%.o:: $(PATHT)%.c
@@ -116,29 +111,17 @@ $(PATHRO):
 $(PATHL):
 	$(MKDIR) $(PATHL)
 
-# the crypto library from OpenSSL is copied and renamed
-$(CRYPTO_LIB_PATH): $(PATHL)
-	$(COPY) $(OPENSSL_LIB_CRYPTO) $@
-# renaming a shared library is not enough. It's name/path is part of the file itself and encoded within it.
-# For Linux it is enough to change the soname (id) to the new file name, as Linux will search in
-# various directories for it
-ifeq ($(shell uname -s),Linux)
-	patchelf --set-soname lib$(CRYPTO_LIB).$(LIBRARY_EXTENSION) $@
-endif
-# Mac OS will look for the library only in the path that is defined in id. We change it using the variable rpath at
-# the beginning and adding the file name afterwards. The value for rpath is defined in $LINK_TEST and $LINK_RELEASE
-# respectively, when the test and the besu_native library are linked
-#
-# More details about native library resolution on Mac OS can be found here:
-# https://medium.com/@donblas/fun-with-rpath-otool-and-install-name-tool-e3e41ae86172
-ifeq ($(shell uname -s),Darwin)
-	install_name_tool -id "@rpath/lib$(CRYPTO_LIB).$(LIBRARY_EXTENSION)" $@
-endif
-
-# the release build is created without debugging symbols and copied to the folder release/
+# the release build links OpenSSL statically with all symbols hidden, exporting only p256_* functions.
+# This prevents OpenSSL symbols from leaking into the JVM process and conflicting with other native
+# libraries (e.g. SoftHSM2, cloud HSM PKCS#11 clients) that depend on system OpenSSL.
 release_build: $(PATHRO)constants.o $(PATHRO)ec_key.o $(PATHRO)ec_key_recovery.o $(PATHRO)ec_sign.o $(PATHRO)ec_verify.o $(PATHRO)utils.o
-	$(COPY) $(CRYPTO_LIB_PATH) $(PATHRE)
-	$(LINK_RELEASE) -Wl,-rpath ./ $^ -l$(CRYPTO_LIB) -fPIC -shared $(CFLAGS) -o $(PATHRE)libbesu_native_ec.$(LIBRARY_EXTENSION)
+	echo "{ global: p256_*; local: *; };" > $(PATHRE)version.script
+	gcc -shared -fPIC \
+		-Wl,-Bsymbolic \
+		-Wl,--exclude-libs,ALL \
+		-Wl,--version-script=$(PATHRE)version.script \
+		$^ $(OPENSSL_STATIC_LIB) \
+		-o $(PATHRE)libbesu_native_ec.$(LIBRARY_EXTENSION)
 	$(COPY) src/besu_native_ec.h $(PATHRE)
 
 $(PATHRO)%.o: $(PATHS)%.c $(PATHRO) $(PATHRE)
@@ -149,7 +132,7 @@ clean:
 	$(CLEANUP) $(PATHRO)*.o
 	$(CLEANUP) $(PATHB)*.$(TEST_EXTENSION)
 	$(CLEANUP) $(PATHR)*.txt
-	$(CLEANUP) $(PATHRE)*.$(LIBRARY_EXTENSION) $(PATHRE)*.h
+	$(CLEANUP) $(PATHRE)*.$(LIBRARY_EXTENSION) $(PATHRE)*.h $(PATHRE)version.script
 	$(CLEANUP) $(PATHL)*.*
 
 .PRECIOUS: $(PATHB)test_%.$(TEST_EXTENSION)

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,13 @@ $(PATHL):
 # This prevents OpenSSL symbols from leaking into the JVM process and conflicting with other native
 # libraries (e.g. SoftHSM2, cloud HSM PKCS#11 clients) that depend on system OpenSSL.
 release_build: $(PATHRO)constants.o $(PATHRO)ec_key.o $(PATHRO)ec_key_recovery.o $(PATHRO)ec_sign.o $(PATHRO)ec_verify.o $(PATHRO)utils.o
+ifeq ($(shell uname -s),Darwin)
+	echo "_p256_key_recovery\n_p256_sign\n_p256_verify\n_p256_verify_malleable_signature" > $(PATHRE)exported_symbols.txt
+	gcc -shared -fPIC \
+		-Wl,-exported_symbols_list,$(PATHRE)exported_symbols.txt \
+		$^ $(OPENSSL_STATIC_LIB) \
+		-o $(PATHRE)libbesu_native_ec.$(LIBRARY_EXTENSION)
+else
 	echo "{ global: p256_*; local: *; };" > $(PATHRE)version.script
 	gcc -shared -fPIC \
 		-Wl,-Bsymbolic \
@@ -122,6 +129,7 @@ release_build: $(PATHRO)constants.o $(PATHRO)ec_key.o $(PATHRO)ec_key_recovery.o
 		-Wl,--version-script=$(PATHRE)version.script \
 		$^ $(OPENSSL_STATIC_LIB) \
 		-o $(PATHRE)libbesu_native_ec.$(LIBRARY_EXTENSION)
+endif
 	$(COPY) src/besu_native_ec.h $(PATHRE)
 
 $(PATHRO)%.o: $(PATHS)%.c $(PATHRO) $(PATHRE)
@@ -132,7 +140,7 @@ clean:
 	$(CLEANUP) $(PATHRO)*.o
 	$(CLEANUP) $(PATHB)*.$(TEST_EXTENSION)
 	$(CLEANUP) $(PATHR)*.txt
-	$(CLEANUP) $(PATHRE)*.$(LIBRARY_EXTENSION) $(PATHRE)*.h $(PATHRE)version.script
+	$(CLEANUP) $(PATHRE)*.$(LIBRARY_EXTENSION) $(PATHRE)*.h $(PATHRE)version.script $(PATHRE)exported_symbols.txt
 	$(CLEANUP) $(PATHL)*.*
 
 .PRECIOUS: $(PATHB)test_%.$(TEST_EXTENSION)

--- a/setup.sh
+++ b/setup.sh
@@ -12,12 +12,18 @@ git submodule init
 git submodule update
 
 cd openssl
-./Configure enable-ec_nistp_64_gcc_128 no-stdio no-ocsp no-nextprotoneg no-module \
+
+# Build OpenSSL as a static library with hidden visibility.
+# This prevents OpenSSL symbols from leaking into the JVM process when
+# libbesu_native_ec is loaded, which would otherwise conflict with other
+# native libraries (e.g. PKCS#11 HSM providers) that depend on system OpenSSL.
+./Configure no-shared -fPIC -fvisibility=hidden \
+            enable-ec_nistp_64_gcc_128 no-stdio no-ocsp no-nextprotoneg no-module \
             no-legacy no-gost no-engine no-dynamic-engine no-deprecated no-comp \
             no-cmp no-capieng no-ui-console no-tls no-ssl no-dtls no-aria no-bf \
             no-blake2 no-camellia no-cast no-chacha no-cmac no-des no-dh no-dsa \
             no-ecdh no-idea no-md4 no-mdc2 no-ocb no-poly1305 no-rc2 no-rc4 no-rmd160 \
             no-scrypt no-seed no-siphash no-siv no-sm2 no-sm3 no-sm4 no-whirlpool
-make build_generated libcrypto.$LIBRARY_EXTENSION
+make build_generated libcrypto.a
 
 cd ../

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-if [[ "$OSTYPE" == "msys" ]]; then
-	LIBRARY_EXTENSION=dll
-elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  LIBRARY_EXTENSION=so
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  LIBRARY_EXTENSION=dylib
-fi
-
 git submodule init
 git submodule update
 


### PR DESCRIPTION
## Summary

  Static-link OpenSSL into `libbesu_native_ec.so` to prevent OpenSSL symbols from leaking into the JVM process global symbol table.

  ## Problem

  `libbesu_native_ec_crypto.so` is a renamed copy of OpenSSL's `libcrypto.so.3` that exports **all** OpenSSL symbols globally. When loaded into a JVM process via
   JNA, these symbols contaminate the global symbol table. Any other native library that depends on system OpenSSL — such as PKCS#11 HSM providers (SoftHSM2, AWS
   CloudHSM client, YubiHSM) — has its OpenSSL calls silently redirected to Besu's stripped-down bundled copy.

  This causes:
  - **SIGSEGV crashes** in `libbesu_native_ec_crypto.so` at `ossl_namemap_empty+0x8`
  - **`CKR_GENERAL_ERROR`** from PKCS#11 signing operations

  Confirmed via `LD_DEBUG=bindings`:
  binding file libsofthsm2.so to /tmp/besu_native_ec_crypto@.../libbesu_native_ec_crypto.so: normal symbol EVP_DigestSign' binding file libsofthsm2.so to
  /tmp/besu_native_ec_crypto@.../libbesu_native_ec_crypto.so: normal symbol EVP_EncryptUpdate'

  This affects any Besu plugin that loads a native library depending on system OpenSSL.

  ## Fix

  - Build OpenSSL as a **static library** (`libcrypto.a`) with `-fPIC -fvisibility=hidden` instead of a shared library
  - Link `libbesu_native_ec.so` against the static lib with `-Wl,-Bsymbolic -Wl,--exclude-libs,ALL` to hide all internal symbols
  - Use a linker version script to export only the 4 `p256_*` JNA entry points
  - **Remove `libbesu_native_ec_crypto.so` entirely** — OpenSSL is now embedded inside `libbesu_native_ec.so`
  - Remove `patchelf` dependency (no longer needed)

  This follows the same approach used by the `boringssl` module in `besu-native`, which already statically links `libcrypto.a`.

  ## Verification

  After the fix, no OpenSSL symbols are exported:
  ```
  $ nm -D release/libbesu_native_ec.so | grep " T "
  000000000006dc70 T p256_key_recovery
  000000000006e4f0 T p256_sign
  000000000006eab0 T p256_verify
  000000000006eb14 T p256_verify_malleable_signature

  $ nm -D release/libbesu_native_ec.so | grep -c "EVP_|EC_|ossl_"
  0
```
  Tested end-to-end: replaced the `secp256r1` jar in Besu with the fixed library and confirmed PKCS#11 signing with SoftHSM2 succeeds inside the Besu JVM
  (previously crashed with SIGSEGV or failed with CKR_GENERAL_ERROR).

  ## Companion Changes (besu-native)

  This PR requires corresponding changes in [besu-native](https://github.com/hyperledger/besu-native):
  - `secp256r1/build.gradle` — remove `libbesu_native_ec_crypto` from all platform copy tasks
  - `secp256r1/src/main/java/.../BesuNativeEC.java` — remove `registerJNA(Library.class, "besu_native_ec_crypto")` call
  - `build.sh` — update `build_secp256r1()` to build OpenSSL as static (`no-shared`, `libcrypto.a`)
  - Update submodule ref to this fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the build/link pipeline to embed OpenSSL into `libbesu_native_ec` and restrict exported symbols, which can impact binary compatibility and cross-platform linking behavior. CI now enforces symbol visibility, so misconfigurations will fail builds.
> 
> **Overview**
> **Static-links OpenSSL into the release native library** by switching from a renamed `libcrypto.so` sidecar to linking `libcrypto.a` directly, with compiler/linker flags to hide OpenSSL internals and export only the `p256_*` entry points.
> 
> Updates the `Makefile` and `setup.sh` to build OpenSSL with `no-shared` and hidden visibility, removes the old `patchelf`/rpath-based shared-lib handling, and adjusts tests to link against the static crypto archive.
> 
> CI is updated to build the release artifact separately, upload release vs test artifacts, and fail the build if `nm` detects leaked `EVP_`/`EC_`/`ossl_` symbols from `libbesu_native_ec.so`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ff458c76781ab27c86d9c0803049b0f87e81b3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->